### PR TITLE
fix: fix the link to the avatar

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ description: Senior majoring in Computer Science at New York University, with a 
 
 # CUSTOMIZE
 # URL of your avatar or profile pic (you could use your GitHub profile pic)
-avatar: https://imgur.com/72e9rQv
+avatar: https://i.imgur.com/72e9rQv.png
 
 # CUSTOMIZE
 #


### PR DESCRIPTION
I found that the avatar in your blog page was not displayed. I visited the link you provided in the `config` file and got the correct link for your avatar.